### PR TITLE
Add vendor version for libgui

### DIFF
--- a/libs/gui/Android.bp
+++ b/libs/gui/Android.bp
@@ -17,13 +17,8 @@ cc_library_headers {
     export_include_dirs: ["include"],
 }
 
-cc_library_shared {
-    name: "libgui",
-    vendor_available: false,
-    vndk: {
-        enabled: true,
-    },
-
+cc_defaults {
+    name: "libgui_defaults",
     clang: true,
     cflags: [
         "-Wall",
@@ -57,7 +52,7 @@ cc_library_shared {
         "-Wno-weak-vtables",
 
         // Allow four-character integer literals
-	"-Wno-four-char-constants",
+        "-Wno-four-char-constants",
 
         // Allow documentation warnings
         "-Wno-documentation",
@@ -169,7 +164,7 @@ cc_library_shared {
         "libEGL",
         "libnativewindow",
         "libui",
-        "android.hidl.token@1.0-utils",
+       "android.hidl.token@1.0-utils",
         "android.hardware.graphics.bufferqueue@1.0",
         "android.hardware.graphics.common@1.1",
     ],
@@ -181,6 +176,21 @@ cc_library_shared {
     export_include_dirs: [
         "include",
     ],
+}
+
+cc_library_shared {
+    name: "libgui",
+    vendor_available: false,
+    vndk: {
+        enabled: true,
+    },
+    defaults: ["libgui_defaults"]
+}
+
+cc_library_shared {
+    name: "libgui_vendor",
+    vendor: true,
+    defaults: ["libgui_defaults"]
 }
 
 subdirs = ["tests"]


### PR DESCRIPTION
libstagefright_omx library need to be extended to vendor which
is depenednet on libgui which is a vndk_private lib.
Creating vendor version so that libstagefright_omx_ext can link
to libgui_vendor.

CRs-Fixed: 2258968
Change-Id: I777eebffc405c8bb74aab270e9f272c806501458